### PR TITLE
Allow logic operators with int

### DIFF
--- a/src/ttboard/types/logic_array.py
+++ b/src/ttboard/types/logic_array.py
@@ -359,6 +359,10 @@ class LogicArray(ArrayLike):
         return int(self)
 
     def __and__(self, other: "LogicArray") -> "LogicArray":
+        if isinstance(other, int):
+            # Allow &= ~x to work
+            other &= (1 << len(self)) - 1
+            return LogicArray(value=(other & self.to_unsigned()), range=self._range)
         if not isinstance(other, LogicArray):
             return NotImplemented
         if len(self) != len(other):
@@ -368,6 +372,8 @@ class LogicArray(ArrayLike):
         return LogicArray(a & b for a, b in zip(self, other))
 
     def __or__(self, other: "LogicArray") -> "LogicArray":
+        if isinstance(other, int):
+            return LogicArray(value=(other | self.to_unsigned()), range=self._range)
         if not isinstance(other, LogicArray):
             return NotImplemented
         if len(self) != len(other):
@@ -377,6 +383,8 @@ class LogicArray(ArrayLike):
         return LogicArray(a | b for a, b in zip(self, other))
 
     def __xor__(self, other: "LogicArray") -> "LogicArray":
+        if isinstance(other, int):
+            return LogicArray(value=(other ^ self.to_unsigned()), range=self._range)
         if not isinstance(other, LogicArray):
             return NotImplemented
         if len(self) != len(other):


### PR DESCRIPTION
This allows test scripts such as collatz that set the pins using `|=` and `&=`to work.