### PR TITLE
print stack trace on all exceptions

### DIFF
--- a/src/ttboard/cocotb/__init__.py
+++ b/src/ttboard/cocotb/__init__.py
@@ -50,6 +50,9 @@ class Runner:
                 self.tests_to_run[nm](dut)
                 dut._log.warn(f"*** Test '{nm}' PASS ***")
             except Exception as e:
+                buf = io.StringIO()
+                sys.print_exception(e, buf)
+                dut._log.error(buf.getvalue())
                 if len(e.args):
                     dut._log.error(f"T*** Test '{nm}' FAIL: {e.args[0]} ***")
                     if e.args[0] is None or not e.args[0]:
@@ -58,9 +61,6 @@ class Runner:
                         failures[nm] = e.args[0]
                         
                 else:
-                    buf = io.StringIO()
-                    sys.print_exception(e, buf)
-                    dut._log.error(buf.getvalue())
                     failures[nm] = " "
                     
                 num_failures += 1


### PR DESCRIPTION
Non-assert exceptions in the testbench code don't produce a traceback, which makes debugging harder. Example:

```
from ttboard import cocotb

@cocotb.test()
async def test_exception(dut):
    a = []
    dut._log.info(a[0])

if __name__ == '__main__':
    from ttboard.cocotb.dut import DUTWrapper   
    cocotb.get_runner().test(DUTWrapper())
```

Ouput:

```
MPY: soft reboot
db init: 135392
user conf loaded: 139680
ttboard.demoboard: Demoboard starting up in mode ASIC_RP_CONTROL
ttboard.pins.pins: Setting mode to ASIC_RP_CONTROL
ttboard.boot.rom: Got ROM data shuttle=tt04
repo=TinyTapeout/tinytapeout-04

ttboard.project_mux: Disable (selecting project 0)
ttboard.project_mux: Loading shuttle file /shuttles/tt04.json
ttboard.project_mux: Enable design tt_um_factory_test
ttboard.demoboard: Resetting system clock to default 1.25e+08Hz
ttboard.demoboard: Clocking at 10Hz
ttboard.demoboard: First time loading: Toggling project reset
ttboard.demoboard: Changing reset to output mode
DUT: *** Running Test 1/1: test_exception ***
DUT: T*** Test 'test_exception' FAIL: list index out of range ***
DUT: 1/1 tests failed
DUT: *** Summary ***
DUT: 	FAIL	test_exception	list index out of range
```