### PR TITLE
handle Timer without Clock

### DIFF
--- a/src/ttboard/cocotb/triggers/timer.py
+++ b/src/ttboard/cocotb/triggers/timer.py
@@ -19,17 +19,20 @@ class Timer(Awaitable):
     def run_timer(self):
         all_clocks = Clock.all()
         # print(f"All clocks on timer: {all_clocks}")
-        fastest_clock = all_clocks[0]
-        time_increment = fastest_clock.half_period
-        target_time = SystemTime.current() + self.time
-        increment_count = 0
-        while SystemTime.current() < target_time:
-            if increment_count % 1000 == 0:
-                print(f"Systime: {SystemTime.current()} (target {target_time})")
-            
-            increment_count += 1
-            SystemTime.advance(time_increment)
+        if all_clocks:
+            fastest_clock = all_clocks[0]
+            time_increment = fastest_clock.half_period
+            target_time = SystemTime.current() + self.time
+            increment_count = 0
+            while SystemTime.current() < target_time:
+                if increment_count % 1000 == 0:
+                    print(f"Systime: {SystemTime.current()} (target {target_time})")
                 
+                increment_count += 1
+                SystemTime.advance(time_increment)
+        else:
+            SystemTime.advance(self.time)
+
                 
     def __iter__(self):
         return self


### PR DESCRIPTION
Using `Timer` without setting up a `Clock` raises an IndexError:

```
from ttboard import cocotb
from ttboard.cocotb.triggers import Timer

@cocotb.test()
async def test_timer(dut):
    await Timer(10, units='ms')

if __name__ == '__main__':
    from ttboard.cocotb.dut import DUTWrapper   
    cocotb.get_runner().test(DUTWrapper())
```

Output:

```
MPY: soft reboot
db init: 128240
user conf loaded: 130240
ttboard.demoboard: Demoboard starting up in mode ASIC_RP_CONTROL
ttboard.pins.pins: Setting mode to ASIC_RP_CONTROL
ttboard.boot.rom: Got ROM data shuttle=tt04
repo=TinyTapeout/tinytapeout-04

ttboard.project_mux: Disable (selecting project 0)
ttboard.project_mux: Loading shuttle file /shuttles/tt04.json
ttboard.project_mux: Enable design tt_um_factory_test
ttboard.demoboard: Resetting system clock to default 1.25e+08Hz
ttboard.demoboard: Clocking at 10Hz
ttboard.demoboard: First time loading: Toggling project reset
ttboard.demoboard: Changing reset to output mode
DUT: *** Running Test 1/1: test_timer ***
DUT: T*** Test 'test_timer' FAIL: list index out of range ***
DUT: 1/1 tests failed
DUT: *** Summary ***
DUT: 	FAIL	test_timer	list index out of range
```

The exception happens at `ttboard/cocotb/triggers/timer.py` line 22: https://github.com/TinyTapeout/tt-micropython-firmware/blob/bb061d2e7ac162f848408f9f5a0abe1b6a0fb322/src/ttboard/cocotb/triggers/timer.py#L22

This PR is a quick and dirty fix for this specific case when `all_clocks` is empty. There are some other edge cases where either `self.time` or some of the other clocks aren't a multiple of the fastest clock, but we can deal with them later.