### PR TITLE
Support for easy serial-con file transfers

### DIFF
--- a/bin/transfer_file_to_rp2.py
+++ b/bin/transfer_file_to_rp2.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+'''
+Sample implementation of file upload to RP2 FS that doesn't rely on anything but a 
+connection to USB serial.
+
+This just puts the RP2 into raw mode, imports a module that is normally ignored, and 
+shoots over the file in chunks, b64 encoded.  Easy-peasy.
+
+It also provides a digest (SHA256) if you want to verify validity, demoed here.
+
+Run with
+
+  transfer_file_to_rp2.py -p /dev/ttyACM0 LOCALFILE /FULL/PATH/ON/REMOTE/FS/FILE
+
+'''
+import os
+import serial
+import base64
+import argparse
+import time
+import hashlib
+
+ChunkSize = 256
+
+def read_pending(ser):
+    data = b''
+    while ser.in_waiting:
+        data += ser.read(ser.in_waiting)
+        # print(f"GOT DATA: {data}")
+        time.sleep(0.005)
+    return data
+def read_until(ser, ending, timeout=5):
+    """
+    Read from serial until the ending byte sequence is found.
+    """
+    data = b''
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        if ser.in_waiting:
+            data += ser.read(ser.in_waiting)
+            # print(f"GOT DATA: {data}")
+            if data.endswith(ending):
+                return data[:-len(ending)]
+        time.sleep(0.01)
+    raise TimeoutError("Timeout waiting for ending sequence")
+
+def enter_raw_repl(ser):
+    """
+    Enter raw REPL mode on the MicroPython device.
+    """
+    # Interrupt any running code with Ctrl-C twice
+    ser.write(b'\r\x03\x03')
+    time.sleep(0.1)
+    # Clear any buffered output
+    if ser.in_waiting:
+        ser.read(ser.in_waiting)
+    # Enter raw REPL with Ctrl-A
+    ser.write(b'\r\x01')
+    # Expect the raw REPL banner
+    banner = read_until(ser, b'raw REPL; CTRL-B to exit\r\n>')
+    if not banner:
+        raise RuntimeError("Failed to enter raw REPL")
+
+def exec_command(ser, command, expect_output=False):
+    """
+    Execute a command in raw REPL and return the output if expected.
+    """
+    # print(f"EXEC COMMAND: {command}")
+    print('.', end='', flush=True)
+    # Send the command followed by Ctrl-D to execute
+    ser.write(command.encode('utf-8') + b'\x04')
+    # Read until Ctrl-D (end of output)
+    if expect_output:
+        time.sleep(0.3)
+        
+    output = read_pending(ser)
+    msg = b''
+    if len(output):
+        msg = output.replace(b'OK\x04\x04>', b'')
+        msg = msg.replace(b'\x04', b'')
+        msg = msg.replace(b'OK', b'')
+        msg = msg.replace(b'>', b'')
+        if len(msg):
+            print(msg)
+    # In raw REPL, errors appear in output; check for them
+    if b'Traceback' in output or b'Error' in output:
+        raise RuntimeError(f"Execution error: {output.decode('utf-8', errors='ignore')}")
+    if expect_output and len(msg):
+        return msg.decode('utf-8', errors='ignore').strip()
+    return None
+
+def main():
+    parser = argparse.ArgumentParser(description="Transfer file to MicroPython device via raw REPL")
+    parser.add_argument('-p', '--port', required=True, help="Serial port to connect to (e.g., COM3 or /dev/ttyACM0)")
+    parser.add_argument('local_file_to_send', help="Local file to send")
+    parser.add_argument('file_path_to_write', help="Remote (full) file path to write to device (/path/to/file.ext)")
+    args = parser.parse_args()
+    
+    if not os.path.exists(args.local_file_to_send):
+        print(f'I cannot seem to find "{args.local_file_to_send}" to send?')
+        return
+    
+    hasher = hashlib.sha256()
+    
+
+    # Open serial connection (assuming default baudrate for MicroPython)
+    with serial.Serial(args.port, 115200, timeout=5) as ser:
+        enter_raw_repl(ser)
+
+        import_cmd = f"from ttboard.util.file_xfer import *\r\n"
+        exec_command(ser, import_cmd)
+        
+        
+        # create the file writer on the device
+        init_cmd = f"f = FileWriter({repr(args.file_path_to_write)})\r\n"
+        exec_command(ser, init_cmd)
+
+        # Read and send the local file in chunks
+        with open(args.local_file_to_send, 'rb') as local_file:
+            while True:
+                chunk = local_file.read(ChunkSize)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+                b64_chunk = base64.b64encode(chunk).decode('ascii')
+                write_cmd = f"f.w({repr(b64_chunk)})\r\n"
+                exec_command(ser, write_cmd)
+
+        # Close the file
+        close_cmd = "f.close()\r\n"
+        exec_command(ser, close_cmd)
+
+        print(f"\nFile sent, expecting hash:\n{hasher.hexdigest()}.\nRequesting digest...")
+        # Get and print the digest
+        digest_cmd = "print(f.digest)\r\n"
+        digest_output = exec_command(ser, digest_cmd, expect_output=True)
+        print(digest_output)
+
+        # Exit raw REPL with Ctrl-B
+        ser.write(b'\x02')
+
+if __name__ == "__main__":
+    main()

--- a/src/ttboard/util/file_xfer.py
+++ b/src/ttboard/util/file_xfer.py
@@ -1,0 +1,82 @@
+'''
+Created on Feb 10, 2026
+
+@author: Pat Deegan
+@copyright: Copyright (C) 2026 Pat Deegan, https://psychogenic.com
+'''
+import binascii 
+import os
+import hashlib
+
+class FileWriter:
+    def __init__(self, fpath:str=None, calculate_hash:bool=True, verbose:bool=False):
+        self._fh = None 
+        self._filepath = None
+        self.verbose = verbose
+        self.calculate_hash = calculate_hash
+        self._hasher = None
+        self.digest_value = None
+        if fpath is not None:
+            self.open(fpath)
+    
+    
+    def open(self, fpath:str):
+        self.close()
+        
+        if not fpath.startswith('/'):
+            if self.verbose:
+                print("WARN: relative path, adding '/'")
+            fpath = f'/{fpath}'
+        self._filepath = fpath
+        
+        # parent dirs ... no os.path here, ugh
+        components = fpath.split('/')
+        num_components = len(components)
+        if num_components > 2:
+            # started with / then something, not just filename
+            for i in range(2, num_components):
+                parent_dir = '/'.join(components[:i])
+                try:
+                    os.stat(parent_dir)
+                except:
+                    # DNE!
+                    if self.verbose:
+                        print(f"DEBUG: creating {parent_dir}")
+                    os.mkdir(parent_dir)
+            
+        if self.verbose:
+            print(f'INFO: open {fpath} for write')
+        self._fh = open(fpath, 'wb')
+        
+        if self.calculate_hash:
+            self.digest_value = None
+            self._hasher = hashlib.sha256()
+        
+    def w(self, b64chunk:str):
+        bin_chunk = binascii.a2b_base64(b64chunk)
+            
+        self._fh.write(bin_chunk)
+        
+        if self.calculate_hash:
+            self._hasher.update(bin_chunk)
+        
+    def write_base64(self, b64chunk):
+        return self.w(b64chunk)
+    
+    def close(self):
+        if self._fh is not None:
+            if self.verbose:
+                print(f"INFO: closing {self._filepath}")
+                if self.calculate_hash:
+                    print(f'INFO: digest {self.digest}')
+            self._fh.close()
+            self._fh = None
+            
+    @property 
+    def digest(self):
+        if self.digest_value is None:
+            if self.calculate_hash and self._hasher:
+                self.digest_value = self._hasher.digest().hex()
+        
+        return self.digest_value
+                


### PR DESCRIPTION
File uploads to RP2 FS that doesn't rely on anything but a connection to USB serial.  This is meant as a way that depends on nothing but the SDK and a means to talk over serial to get files up onto the FS, meaning the protocol can work with Python, web stuff, etc.

It includes a module for the SDK and a sample implementation that exercises it from desktop.
