### PR TITLE
Correct platform clock writer to SET/CLR GPIO_OUT

### DIFF
--- a/src/ttboard/util/platform/rp2350.py
+++ b/src/ttboard/util/platform/rp2350.py
@@ -137,7 +137,7 @@ def read_uo_out_byte():
 
 ###@micropython.native
 def read_clock():
-    # clock is on GPIO21
+    # clock is on GPIO16
     return ((machine.mem32[0xd0000010] & (1 << 16)) >> 16)
    
 ###@micropython.native
@@ -145,7 +145,7 @@ def write_clock(val):
     # not a huge optimization, as this is a single bit, 
     # but 5% or so counts when using the microcotb tests
     if val:
-        machine.mem32[0xd0000038] = (1 << 16) 
+        machine.mem32[0xd0000018] = (1 << 16) 
     else:
-        machine.mem32[0xd0000040] = (1 << 16)
+        machine.mem32[0xd0000020] = (1 << 16)
     


### PR DESCRIPTION
This PR corrects the register address for clocking the design via the RP2350 to GPIO_OUT_SET, and GPIO_OUT_CLR. See Section 3.1.11 of RP2350 datasheet.

A related comment regarding the GPIO map of RP_PROJCLK is updated to match the implementation.

Reproduce:

1.    Nuke flash memory with (!WARNING! this intentionally wipes device memory):
    https://github.com/Gadgetoid/pico-universal-flash-nuke/releases/tag/v1.1.0

2.    Flash with latest ttdbv3 branch tt-micropython-firmware release https://github.com/TinyTapeout/tt-micropython-firmware/actions/runs/21886123591. Note that RP2350 is not yet supported on main.

file used:
tt-demo-rp2350-ttdbv3.uf2.zip sha256:dd8ea2e43b1f5568d92a73652fe1f7d433c0785f19f4456fa23135541eb2446a

3.  Run tt_um_factory_test

Counter test fails as counter never increments despite the test advancing through await ClockCycle.
<img width="2950" height="604" alt="Image" src="https://github.com/user-attachments/assets/c3d6f252-e656-4819-aa4c-b744e9cebf26" />

4. Nuke flash memory with (!WARNING! this intentionally wipes device memory):
    https://github.com/Gadgetoid/pico-universal-flash-nuke/releases/tag/v1.1.0

5. Flash with patched ttdbv3 branch
    Commit: https://github.com/pgfarley/tt-micropython-firmware-for-tophat/commit/a3934f7895dafd2c20eee63b72d9ebe4e7a04460

Build: https://github.com/pgfarley/tt-micropython-firmware-for-tophat/actions/runs/22355986513
tt-demo-rp2350-ttdbv3-RP2350-register-fix.uf2 sha256:33b639665b2cd85ce5246c4ca4d8a382041d3fa8708c9eb49058e7948a0c3485

6. run tt_um_factory_test

<img width="2950" height="604" alt="Image" src="https://github.com/user-attachments/assets/0b6781ec-40ac-4640-934a-c11fa1e2bfa1" />
