### PR TITLE
docs: fix reset function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ True
 
 ## Project clocking and reset
 
-To put a project in or out of reset, use `project_reset(BOOL)`
+To put a project in or out of reset, use `reset_project(BOOL)`
 
 ```
 # hold in reset


### PR DESCRIPTION
`tt.project_reset()` doesn't seem to exist on my ETR FPGA board (doesn't tab-complete), but `tt.reset_project()` does.