### PR TITLE
warning on pin() setting when mode not OUT

### DIFF
--- a/src/ttboard/pins/standard.py
+++ b/src/ttboard/pins/standard.py
@@ -123,6 +123,8 @@ class StandardPin:
     
     def __call__(self, value:int=None):
         if value is not None:
+            if self.mode != Pin.OUT:
+                log.warning('Request to set value on pin, but mode != Pin.OUT')
             return self.raw_pin.value(value)
         return self.raw_pin.value()
     


### PR DESCRIPTION
Added a warning to the standard pin() call when setting a value on something that isn't mode Pin.OUT